### PR TITLE
Updated ProjectFile, ViewModel and View for Project

### DIFF
--- a/src/DevOpsFlex.ProjectDigger/ProjectDigger/ViewModels/ProjectViewModel.cs
+++ b/src/DevOpsFlex.ProjectDigger/ProjectDigger/ViewModels/ProjectViewModel.cs
@@ -29,6 +29,38 @@
             }
         }
 
+        public Brush StyleCopFileFill
+        {
+            get
+            {
+                switch (_projectFile.HasStyleCopSettingsFile)
+                {
+                    case false:
+                        return Brushes.Orange;
+                    case true:
+                        return Brushes.Transparent;
+                    default:
+                        return Brushes.Transparent;
+                }
+            }
+        }
+
+        public Brush StyleCopFileStroke
+        {
+            get
+            {
+                switch (_projectFile.HasStyleCopSettingsFile)
+                {
+                    case false:
+                        return Brushes.Black;
+                    case true:
+                        return Brushes.Transparent;
+                    default:
+                        return Brushes.Transparent;
+                }
+            }
+        }
+
         public Brush ResharperFill
         {
             get

--- a/src/DevOpsFlex.ProjectDigger/ProjectDigger/Views/ProjectView.xaml
+++ b/src/DevOpsFlex.ProjectDigger/ProjectDigger/Views/ProjectView.xaml
@@ -11,6 +11,7 @@
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
 
@@ -22,7 +23,7 @@
 
         <core:OutlinedTextBlock Grid.Column="1"
                                 Text="SCop"
-                                Margin="0 0 10 0"
+                                Margin="0 0 0 0"
                                 Fill="{Binding Path=StyleCopFill}"
                                 Stroke="Black"
                                 StrokeThickness="1"
@@ -30,6 +31,15 @@
                                 FontWeight="Bold" />
 
         <core:OutlinedTextBlock Grid.Column="2"
+                                Text="!"
+                                Margin="0 0 10 0"
+                                Fill="{Binding Path=StyleCopFileFill}"
+                                Stroke="{Binding Path=StyleCopFileStroke}"
+                                StrokeThickness="1"
+                                FontSize="20"
+                                FontWeight="Bold" />
+
+        <core:OutlinedTextBlock Grid.Column="3"
                                 Text="R#"
                                 Margin="0 0 10 0"
                                 Fill="{Binding Path=ResharperFill}"
@@ -39,7 +49,7 @@
                                 FontWeight="Bold" />
 
         <TextBlock x:Name="ProjectName"
-                   Grid.Column="3"
+                   Grid.Column="4"
                    FontSize="16"
                    FontWeight="Bold"
                    Foreground="DarkBlue"


### PR DESCRIPTION
You had a property that represented whether a StyleCop.settings file was included in the project, however this wasn't referenced anywhere! Noob!

I've updated the ProjectFile constructor and the Project View and ViewModel to show an orange (!) next to the SCop indicator if there is no StyleCop file.

Your version is in .NET v4.6 so I've only committed changes to the 3 files I have actually changed, rather than all my millions of changes due to version bindings.
